### PR TITLE
Fixed uninitialized object error in form, and remove binding error in js.

### DIFF
--- a/lib/rails/form_helper.rb
+++ b/lib/rails/form_helper.rb
@@ -12,6 +12,7 @@ ActionView::Helpers::FormBuilder.class_eval do
     options[:escape_template] = options.key?(:escape_template) ? options[:escape_template] : true
     
     output = @template.capture { fields_for(association, &block) }
+    output ||= template.raw ""
     
     if options[:show_empty] and self.object.send(association).empty?
       output.safe_concat @template.capture { yield nil } 

--- a/vendor/assets/javascripts/jquery.nested-fields.js
+++ b/vendor/assets/javascripts/jquery.nested-fields.js
@@ -29,7 +29,7 @@
     init: function(options) {
       return this.each(function() {        
         var $this = $(this);
-        if($(this).data('nested-fields.options')) {
+        if($this.data('nested-fields.options')) {
           log('Nested fields already defined for this element. If you want to redefine options, destroy it and init again.');
           return $this;
         }
@@ -42,7 +42,7 @@
         $this.data('nested-fields.options', options); 
 
         bindInsertToAdd(options);
-        bindRemoveToItems(options);
+        bindRemoveToItems(options, $this);
       });
     },
     
@@ -105,8 +105,8 @@
     });
   }
   
-  function bindRemoveToItems(options) {
-    $(options.itemSelector, options.containerSelector).each(function(i, item) {
+  function bindRemoveToItems(options, $this) {
+    $(options.itemSelector, $this).each(function(i, item) {
       bindRemoveToItem(item, options);
     });
   }
@@ -178,7 +178,7 @@
     if(!options.skipBefore) {
       options.beforeRemove($element, remove);
       if(options.beforeRemove.length <= 1) {
-        insert();
+        remove();
       }
     } else {
       remove();


### PR DESCRIPTION
Hey Lailson,

I fixed a few things in ANF...
1. When there was no object for the form, it was failing because it was trying to call `safe_concat` on `nil`, that is, when the first `template.capture` was `nil`. All I did was provide a default.
2. When `$('selector').nestedFields()` was called twice, the remove bindings were added twice to each object, resulting in some funky errors. Instead of evaluating the `itemSelector` in the context of the `containerSelector`, it is evaluated in the context of `$this`.
3. There was an `insert` instead of `remove` resulting in the remove callback failing.

Apart from that, ANF is, well, awesome! I was using Cocoon for the same thing but that was a b•tch to extend – your interface is very clean and flexible.

If you are interested, I am using the following code to restrict insertion/removal based on validations (`max`, `min`, and `count` are set accordingly on the main element):

```
opt = {}
ks = 'item container empty add remove'.split ' '
opt[ "#{k}Selector" ] = ".nested-fields-#{ k }" for k in ks

$ -> $('.nested-fields').each ->
  $app = $ @
  { min, max, count:n } = $app.data()

  tidyInsert = ->
    $( opt.addSelector, $app ).hide() if n >= max
    $( opt.removeSelector, $app ).show() if n >  min

  tidyRemove = ->
    $( opt.addSelector, $app ).show() if n <  max
    $( opt.removeSelector, $app ).hide() if n <= min

  $app.nestedFields $.extend {}, opt,
    beforeInsert : ( item, f ) ->
      return unless n < max
      n += 1
      tidyInsert()
      f()

    beforeRemove : ( item, f ) ->
      return unless n > min
      n -= 1
      tidyRemove()
      f()

  $app.nestedFields 'insert' while n < min
  tidyInsert()
  tidyRemove()
```

Might be a useful default?

Cheers, Alex.
