### PR TITLE
minor annoying bug on safari, works fine on  chrome (have not tested out other browsers)

### DIFF
--- a/vendor/assets/javascripts/jquery.nested-fields.js
+++ b/vendor/assets/javascripts/jquery.nested-fields.js
@@ -211,6 +211,7 @@
       if(confirmed === undefined || confirmed === true) {
         removeItemWithCallbacks(item, options);
       }
+      return false;
     });
   }
   


### PR DESCRIPTION
the url is appeneded with a hash on safari Version 5.1.3 (7534.53.10)
works fine without on chrome!?

Tested it on an older version of safari v4.0.5 and still the same bug.

Bug persists on: http://phonebook.guava.com.br/plain/people/189/edit
